### PR TITLE
Initial RTL support

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,6 +390,9 @@
                     </div>
                 </article>
             </section>
+            <section>
+                RTL support: <button onclick="document.dir = document.dir === 'rtl' ? 'ltr' : 'rtl'">Toggle direction</button>
+            </section>
             <footer>Lissom.CSS - Created by <a href="https://github.com/Looky1173">@Looky1173</a> - 2023</footer>
         </main>
         <script>

--- a/lissom.css
+++ b/lissom.css
@@ -271,12 +271,20 @@ h1::before {
     color: var(--accent-ui);
 }
 
+h1:dir(rtl)::before {
+    right: -2ch;
+}
+
 h2::before {
     content: '##';
     position: absolute;
     left: -3ch;
     color: var(--accent-ui);
     opacity: 0.9;
+}
+
+h2:dir(rtl)::before {
+    right: -3ch;
 }
 
 h3::before {
@@ -287,12 +295,20 @@ h3::before {
     opacity: 0.8;
 }
 
+h3:dir(rtl)::before {
+    right: -4ch;
+}
+
 h4::before {
     content: '####';
     position: absolute;
     left: -5ch;
     color: var(--accent-ui);
     opacity: 0.7;
+}
+
+h4:dir(rtl)::before {
+    right: -5ch;
 }
 
 h5::before {
@@ -303,12 +319,20 @@ h5::before {
     opacity: 0.6;
 }
 
+h5:dir(rtl)::before {
+    right: -6ch;
+}
+
 h6::before {
     content: '######';
     position: absolute;
     left: -7ch;
     color: var(--accent-ui);
     opacity: 0.5;
+}
+
+h6:dir(rtl)::before {
+    right: -7ch;
 }
 
 h1[data-no-heading-level]::before,
@@ -436,6 +460,10 @@ progress:indeterminate {
     background-position: top left;
     background-repeat: no-repeat;
     background-size: 150% 150%;
+}
+
+progress:indeterminate:dir(rtl) {
+    animation-direction: reverse;
 }
 
 progress:indeterminate::-webkit-progress-bar {


### PR DESCRIPTION
This adds an initial RTL support to the project,

What is RTL?

Languages like Arabic, Hebrew and Persian use a script that typesets the letters from right to left https://en.wikipedia.org/wiki/Right-to-left_script instead of Latin's left to right.

Does supporting RTL languages matter?

For example search RTL in https://sprucecss.com and https://www.muicss.com it can matter for the sake completion but you can also reject this if you don't like the support.

How to reproduce the issue?

First of all use Firefox or Safari as this fix uses this https://developer.mozilla.org/en-US/docs/Web/CSS/:dir CSS feature which currently isn't support in Chromium based browsers, https://crbug.com/576815

pull the update repository, click on "Toggle direction" button at the end of demo page. You'll see something this,

<img width="700" alt="image" src="https://github.com/lissomware/css/assets/833473/a8732ed5-2725-457d-92f4-c47fabae918d">

the #'s should be right instead of left. So update the minified version and reopen the demo and you'll see which is expected:

<img width="408" alt="image" src="https://github.com/lissomware/css/assets/833473/6e18140d-4821-4700-b007-d1a504b2d6b9">

This change applies direction considerations to indeterminate progress and headers but the open-quote close-quote signs also need to be flipped for RTL which this change hasn't considered yet.

<img width="679" alt="image" src="https://github.com/lissomware/css/assets/833473/57749e18-2c1a-481d-b625-c5ffd62d2ff7">

Also different kind of quotes are used not only in French (fr) (which is already considered) but also in Ukrainian (uk), Russian (ru), Persian (fa), etc.
 
Can it work somehow in Chromium also?

Yes, one can target parent direction attribute using a simpler selector like `[dir=rtl] h6::before` instead of `h6:dir(rtl)::before` but that become buggy when direction is applied using CSS `direction: rtl` instead of attribute `dir="rtl"`, or dir="auto" is used (to let the browser detect the direction automatically), or there is multiple nested layer of direction change but still is better than no support if `dir(rtl)` isn't acceptable.

Hopefully you'll like the solution as I'd say considering such from the beginning will result in later decisions considering this need better.
