### PR TITLE
img fix

### DIFF
--- a/lissom.css
+++ b/lissom.css
@@ -374,7 +374,7 @@ hr:after {
 
 img {
     border-radius: 0.6em;
-    width: 100%;
+    max-width: 100%;
     height: auto;
     transition: border-radius 100ms linear;
 }
@@ -538,3 +538,5 @@ ins {
 del {
     background-color: var(--semantic-red);
 }
+
+::selection {background-color: lavender}


### PR DESCRIPTION
image is always gigantic when width is set to 100%. should be max-width instead.